### PR TITLE
Update MSBuild project TFM

### DIFF
--- a/src/THNETII.AzureDevOps.Pipelines.MSBuild/THNETII.AzureDevOps.Pipelines.MSBuild.csproj
+++ b/src/THNETII.AzureDevOps.Pipelines.MSBuild/THNETII.AzureDevOps.Pipelines.MSBuild.csproj
@@ -22,6 +22,11 @@ E.g. the Azure DevOps MSBuild logger that logs MSBuild output in a format that i
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.4.0" PrivateAssets="All" />
   </ItemGroup>
 
+  <!-- Remove SourceLink because of .NET Core App TFM -->
+  <ItemGroup>
+    <PackageReference Remove="Microsoft.SourceLink.GitHub" />
+  </ItemGroup>
+
   <ItemGroup>
     <Compile Include="..\THNETII.AzureDevOps.Pipelines.VstsTaskSdk\**\*.cs" />
   </ItemGroup>

--- a/src/THNETII.AzureDevOps.Pipelines.MSBuild/THNETII.AzureDevOps.Pipelines.MSBuild.csproj
+++ b/src/THNETII.AzureDevOps.Pipelines.MSBuild/THNETII.AzureDevOps.Pipelines.MSBuild.csproj
@@ -3,7 +3,9 @@
 
   <PropertyGroup>
     <LangVersion>7.3</LangVersion>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(NoNetFramework)'!='true'">$(TargetFrameworks);net472</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildDefaultTargetFramework)'!=''">netcoreapp2.1</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RootNamespace>THNETII.AzureDevOps.Pipelines.MSBuild</RootNamespace>
     <Product>TH-NETII Azure DevOps Pipelines MSBuild support class library</Product>

--- a/src/THNETII.AzureDevOps.Pipelines.VstsTaskSdk/VstsLoggingCommand.cs
+++ b/src/THNETII.AzureDevOps.Pipelines.VstsTaskSdk/VstsLoggingCommand.cs
@@ -253,7 +253,11 @@ namespace THNETII.AzureDevOps.Pipelines.VstsTaskSdk
 
             foreach (var (token, replacement) in replaceMappings)
             {
-                data = data.Replace(token, replacement);
+                data = data.Replace(token, replacement
+                #if NETCOREAPP
+                    , StringComparison.Ordinal
+                #endif // NETCOREAPP
+                    );
             }
 
             return data;


### PR DESCRIPTION
The `Microsoft.Build` nuget package has changed its TFMs to `net472` and `netcoreapp2.1`. The MSBuild logger project must be updated to reflect this change