### PR TITLE
Fix .NET Core Azure Pipelines definition

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,14 +3,13 @@
   // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
   // List of extensions which should be recommended for users of this workspace.
   "recommendations": [
-    "ms-vscode.csharp",
     "editorconfig.editorconfig",
-    "sidneys1.gitconfig",
     "codezombiech.gitignore",
+    "ms-dotnettools.csharp",
     "davidanson.vscode-markdownlint",
     "tintoy.msbuild-project-tools",
     "humao.rest-client",
-    "redhat.vscode-yaml"
+    "redhat.vscode-yaml",
   ],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
   "unwantedRecommendations": [

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,6 @@ resources:
     type:       github
     name:       thnetii/azure-pipelines
     endpoint:   thnetii
-    ref:        refs/heads/march-fix
 jobs:
 - template: templates/dotnetcore/azure-pipelines.yml@templates
   parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,7 @@ resources:
     type:       github
     name:       thnetii/azure-pipelines
     endpoint:   thnetii
+    ref:        refs/heads/march-fix
 jobs:
 - template: templates/dotnetcore/azure-pipelines.yml@templates
   parameters:

--- a/templates/dotnetcore/azure-pipelines.yml
+++ b/templates/dotnetcore/azure-pipelines.yml
@@ -8,7 +8,7 @@ parameters:
 - name:     poststeps
   type:     stepList
   default:  []
-  
+
 - name:     defaultPool
   type:     object
   default:
@@ -25,6 +25,47 @@ parameters:
   # testProjects: '' # '[Tt]est/*/*.csproj'
   # arguments:    ''
   # addArguments: ''
+
+- name:     restore
+  type:     object
+  default:  {}
+  # skip:               true
+  # displayNameSuffix:  ''
+  # condition:          ''
+  # projects:           ''
+  # arguments:          ''
+- name:     build
+  type:     object
+  default:  {}
+  # skip:               true
+  # displayNameSuffix:  ''
+  # condition:          ''
+  # projects:           ''
+  # arguments:          ''
+- name:     test
+  type:     object
+  default:  {}
+  # skip:               true
+  # displayNameSuffix:  ''
+  # condition:          ''
+  # projects:           ''
+  # arguments:          ''
+- name:     pack
+  type:     object
+  default:  {}
+  # skip:               true
+  # displayNameSuffix:  ''
+  # condition:          ''
+  # projects:           ''
+  # arguments:          ''
+- name:     publish
+  type:     object
+  default:  {}
+  # skip:               true
+  # displayNameSuffix:  ''
+  # condition:          ''
+  # projects:           ''
+  # arguments:          ''
 
 - name:     debugConfiguration
   type:     object


### PR DESCRIPTION
Address the error during CI builds:
> Pipeline configuration error:
/templates/dotnetcore/azure-pipelines.yml@templates (Line: 154, Col: 5): Key not found 'restore'
/templates/dotnetcore/azure-pipelines.yml@templates (Line: 156, Col: 5): Key not found 'build'
/templates/dotnetcore/azure-pipelines.yml@templates (Line: 158, Col: 5): Key not found 'test'
/templates/dotnetcore/azure-pipelines.yml@templates (Line: 160, Col: 5): Key not found 'pack'
/templates/dotnetcore/azure-pipelines.yml@templates (Line: 164, Col: 7): Key not found 'publish'
/templates/dotnetcore/azure-pipelines.yml@templates (Line: 166, Col: 7): Key not found 'publish'
/templates/dotnetcore/azure-pipelines.yml@templates (Line: 169, Col: 7): Key not found 'publish'
/templates/dotnetcore/azure-pipelines.yml@templates (Line: 171, Col: 7): Key not found 'publish'
/templates/dotnetcore/azure-pipelines.yml@templates (Line: 174, Col: 7): Key not found 'publish'
/templates/dotnetcore/azure-pipelines.yml@templates (Line: 176, Col: 7): Key not found 'publish'