### PR TITLE
Remove MSBuild logger from .NET Core Pipeline

### DIFF
--- a/templates/dotnetcore/azure-pipelines.yml
+++ b/templates/dotnetcore/azure-pipelines.yml
@@ -16,7 +16,7 @@ parameters:
 
 - name:     defaultArguments
   type:     string
-  default:  -p:BuildId=$(Build.BuildId) -p:BuildSourceBranch=$(Build.SourceBranch) -logger:THNETII.AzureDevOps.Pipelines.MSBuild.AzureDevOpsLogger,"$(Build.SourcesDirectory)/bld/THNETII.AzureDevOps.Pipelines.MSBuild/lib/netcoreapp2.1/THNETII.AzureDevOps.Pipelines.MSBuild.dll" -nodeReuse:false
+  default:  -p:BuildId=$(Build.BuildId) -p:BuildSourceBranch=$(Build.SourceBranch) -nodeReuse:false
 - name:     common
   type:     object
   default:  {}

--- a/templates/dotnetcore/jobs/steps.yml
+++ b/templates/dotnetcore/jobs/steps.yml
@@ -62,7 +62,6 @@ steps:
   - ${{ step }}
 - ${{ each step in parameters.presteps }}:
   - ${{ step }}
-- template: ../../msbuildlogger/steps.yml
 - ${{ if not(parameters.restore.skip) }}:
   - task: DotNetCoreCLI@2
     displayName:  dotnet restore ${{ parameters.restore.displayNameSuffix }}


### PR DESCRIPTION
Azure DevOps has started to recognize error and warning output from .NET Core now. Including the MSBuild Logger leads to duplicate warning/error messages